### PR TITLE
Enhance pull request comment handling for dependabot

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -365,7 +365,7 @@ function resolveConflicts($metadata, $pullRequest, $pullRequestUpdated)
         }
         echo "State: " . $pullRequestUpdated->mergeable_state . " - Resolve conflicts - Recreate via bot - Sender: " . $pullRequest->Sender . " ☢️\n";
 
-        if ($pullRequest->Sender !== "dependabot[bot]") {
+        if ($pullRequest->Sender === "dependabot[bot]") {
             $comment = array("body" => "@dependabot recreate");
         } else {
             $comment = array("body" => "@depfu recreate");


### PR DESCRIPTION
### **Description**
- Enhanced the logic for handling pull request comments based on the sender.
- Improved clarity by ensuring the correct comment is sent for `dependabot[bot]`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Update sender condition for pull request comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/pullRequests.php
<li>Updated the condition to check for the sender of the pull request.<br> <li> Changed the comment body for dependabot from "@depfu recreate" to <br>"@dependabot recreate".<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/455/files#diff-a02ee044998cfd579cf9d812f74b51f079e912308e6ce6d9c1337620894ec463">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>