### PR TITLE
Enhance issue handling by removing awaiting triage label for collaborators

### DIFF
--- a/Src/issues.php
+++ b/Src/issues.php
@@ -25,7 +25,7 @@ function handleIssue($issue)
         removeAwaitingTriageLabel($issueUpdated, $metadata);
         return;
     }
-    
+
     $repositoryResponse = doRequestGitHub($metadata["token"], $metadata["repoUrl"], null, "GET");
     $repository = json_decode($repositoryResponse->body);
 
@@ -43,7 +43,7 @@ function handleIssue($issue)
 
     if(in_array($issueUpdated->user->login, $collaboratorsLogins)) {
         removeAwaitingTriageLabel($issueUpdated, $metadata);
-    }    
+    }
 }
 
 function addLabels($issueUpdated, $collaboratorsLogins, $metadata)
@@ -63,7 +63,7 @@ function addLabels($issueUpdated, $collaboratorsLogins, $metadata)
     }
 }
 
-function removeAwaitingTriageLabel($issueUpdated,  $metadata)
+function removeAwaitingTriageLabel($issueUpdated, $metadata)
 {
     $awaitingTriageLabel = "🚦awaiting triage";
     $labels = array_column($issueUpdated->labels, "name");

--- a/Src/issues.php
+++ b/Src/issues.php
@@ -68,7 +68,7 @@ function removeAwaitingTriageLabel($issueUpdated, $metadata)
     $awaitingTriageLabel = "🚦awaiting triage";
     $labels = array_column($issueUpdated->labels, "name");
     if (in_array($awaitingTriageLabel, $labels)) {
-        $url = "{$metadata["issuesUrl"]}/{{$issueUpdated->number}/labels/{$awaitingTriageLabel}";
+        $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$awaitingTriageLabel}";
         doRequestGitHub($metadata["token"], $url, null, "DELETE");
     }
 }


### PR DESCRIPTION
### **Description**
- Implemented logic to automatically remove the "🚦awaiting triage" label for collaborators.
- Added a new function `removeAwaitingTriageLabel` to encapsulate label removal logic.
- Updated existing functions to ensure proper label management based on user roles.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issues.php</strong><dd><code>Enhance issue handling by removing awaiting triage label</code>&nbsp; </dd></summary>
<hr>

src/issues.php
<li>Added functionality to remove the "🚦awaiting triage" label when a <br>collaborator opens an issue.<br> <li> Introduced a new function <code>removeAwaitingTriageLabel</code> to handle label <br>removal.<br> <li> Updated the <code>handleIssue</code> function to call <code>removeAwaitingTriageLabel</code> <br>based on collaborator status.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/456/files#diff-b826551f56f9dba51ed89c86a22de45d218a71bc661b2a9371df0b9b174cea65">+21/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>