### PR TITLE
Enhance error handling in pullRequests.php

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -384,6 +384,9 @@ function updateBranch($metadata, $pullRequestUpdated)
     $headRef = urlencode($pullRequestUpdated->head->ref);
 
     $compareResponse = doRequestGitHub($metadata["token"], "{$metadata["compareUrl"]}{$baseRef}...{$headRef}", null, "GET");
+    if ($compareResponse->statusCode >= 300) {
+        return;
+    }
     $compare = json_decode($compareResponse->body);
 
     if ($compare->behind_by === 0) {


### PR DESCRIPTION
### **Description**
- Introduced error handling for the GitHub API response in the `updateBranch` function.
- The function now returns early if the API response status code is 300 or higher, preventing further processing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Enhance error handling for GitHub API response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/pullRequests.php
<li>Added a check for the response status code from the GitHub API.<br> <li> If the status code is 300 or higher, the function will return early.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/468/files#diff-a02ee044998cfd579cf9d812f74b51f079e912308e6ce6d9c1337620894ec463">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>