### PR TITLE
Refactor label removal in issues.php for better functionality

### DIFF
--- a/Src/issues.php
+++ b/Src/issues.php
@@ -22,7 +22,7 @@ function handleIssue($issue)
     $issueUpdated = json_decode($issueResponse->body);
 
     if ($issueUpdated->assignee != null) {
-        removeAwaitingTriageLabel($issueUpdated, $metadata);
+        removeLabels($issueUpdated, $metadata);
         return;
     }
 
@@ -63,12 +63,14 @@ function addLabels($issueUpdated, $collaboratorsLogins, $metadata)
     }
 }
 
-function removeAwaitingTriageLabel($issueUpdated, $metadata)
+function removeLabels($issueUpdated, $metadata)
 {
-    $awaitingTriageLabel = "🚦awaiting triage";
+    $labelsLookup = ["🚦awaiting triage", "⏳ awaiting response", "🛠 WIP"];
     $labels = array_column($issueUpdated->labels, "name");
-    if (in_array($awaitingTriageLabel, $labels)) {
-        $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$awaitingTriageLabel}";
+    $intersect = array_intersect($labelsLookup, $labels);
+
+    foreach($intersect as $label) {
+        $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$label}";
         doRequestGitHub($metadata["token"], $url, null, "DELETE");
     }
 }

--- a/Src/issues.php
+++ b/Src/issues.php
@@ -22,7 +22,7 @@ function handleIssue($issue)
     $issueUpdated = json_decode($issueResponse->body);
 
     if ($issueUpdated->assignee != null) {
-        removeLabels($issueUpdated, $metadata);
+        removeLabels($issueUpdated, $metadata, true);
         return;
     }
 
@@ -42,7 +42,7 @@ function handleIssue($issue)
     addLabels($issueUpdated, $collaboratorsLogins, $metadata);
 
     if(in_array($issueUpdated->user->login, $collaboratorsLogins)) {
-        removeAwaitingTriageLabel($issueUpdated, $metadata);
+        removeLabels($issueUpdated, $metadata);
     }
 }
 
@@ -63,24 +63,21 @@ function addLabels($issueUpdated, $collaboratorsLogins, $metadata)
     }
 }
 
-function removeLabels($issueUpdated, $metadata)
+function removeLabels($issueUpdated, $metadata, $includeWip = false)
 {
-    $labelsLookup = ["🚦awaiting triage", "⏳ awaiting response", "🛠 WIP"];
+    $labelsLookup = [
+        "🚦awaiting triage",
+        "⏳ awaiting response"
+    ];
+    if ($includeWip === true) {
+        $labelsLookup[] = "🛠 WIP";
+    }
+    
     $labels = array_column($issueUpdated->labels, "name");
     $intersect = array_intersect($labelsLookup, $labels);
 
     foreach ($intersect as $label) {
         $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$label}";
-        doRequestGitHub($metadata["token"], $url, null, "DELETE");
-    }
-}
-
-function removeAwaitingTriageLabel($issueUpdated, $metadata)
-{
-    $awaitingTriageLabel = "🚦awaiting triage";
-    $labels = array_column($issueUpdated->labels, "name");
-    if (in_array($awaitingTriageLabel, $labels)) {
-        $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$awaitingTriageLabel}";
         doRequestGitHub($metadata["token"], $url, null, "DELETE");
     }
 }

--- a/Src/issues.php
+++ b/Src/issues.php
@@ -75,6 +75,16 @@ function removeLabels($issueUpdated, $metadata)
     }
 }
 
+function removeAwaitingTriageLabel($issueUpdated, $metadata)
+{
+    $awaitingTriageLabel = "🚦awaiting triage";
+    $labels = array_column($issueUpdated->labels, "name");
+    if (in_array($awaitingTriageLabel, $labels)) {
+        $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$awaitingTriageLabel}";
+        doRequestGitHub($metadata["token"], $url, null, "DELETE");
+    }
+}
+
 function main()
 {
     $issues = readTable("github_issues");

--- a/Src/issues.php
+++ b/Src/issues.php
@@ -69,7 +69,7 @@ function removeLabels($issueUpdated, $metadata)
     $labels = array_column($issueUpdated->labels, "name");
     $intersect = array_intersect($labelsLookup, $labels);
 
-    foreach($intersect as $label) {
+    foreach ($intersect as $label) {
         $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$label}";
         doRequestGitHub($metadata["token"], $url, null, "DELETE");
     }

--- a/Src/issues.php
+++ b/Src/issues.php
@@ -72,7 +72,7 @@ function removeLabels($issueUpdated, $metadata, $includeWip = false)
     if ($includeWip === true) {
         $labelsLookup[] = "🛠 WIP";
     }
-    
+
     $labels = array_column($issueUpdated->labels, "name");
     $intersect = array_intersect($labelsLookup, $labels);
 


### PR DESCRIPTION
### **Description**
- Refactored the label removal functionality to allow for the removal of multiple labels when manually closing issues.
- Improved code readability and maintainability by renaming functions and using an array for label management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issues.php</strong><dd><code>Refactor label removal functionality in issues.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/issues.php
<li>Renamed <code>removeAwaitingTriageLabel</code> function to <code>removeLabels</code>.<br> <li> Updated the logic to remove multiple labels instead of just one.<br> <li> Introduced a <code>labelsLookup</code> array for label management.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/469/files#diff-6ce0dad4f38891d2e6067af9734b44466fa59d01ddc1ebde9197a21430ec7c4e">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>