### PR TITLE
Update URL structure for GitHub issue labels

### DIFF
--- a/Src/issues.php
+++ b/Src/issues.php
@@ -77,7 +77,7 @@ function removeLabels($issueUpdated, $metadata, $includeWip = false)
     $intersect = array_intersect($labelsLookup, $labels);
 
     foreach ($intersect as $label) {
-        $url = "{$metadata["issuesUrl"]}/{$issueUpdated->number}/labels/{$label}";
+        $url = "{$metadata["issueUrl"]}/labels/{$label}";
         doRequestGitHub($metadata["token"], $url, null, "DELETE");
     }
 }


### PR DESCRIPTION
### **Description**
- Enhanced the `removeLabels` function by updating the URL used for deleting labels.
- Changed the metadata key from `issuesUrl` to `issueUrl` to reflect the correct endpoint.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issues.php</strong><dd><code>Update URL structure for GitHub issue labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/issues.php
<li>Updated the URL structure for label deletion in GitHub issues.<br> <li> Changed <code>issuesUrl</code> to <code>issueUrl</code> for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/472/files#diff-6ce0dad4f38891d2e6067af9734b44466fa59d01ddc1ebde9197a21430ec7c4e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>