### PR TITLE
Enhance pull request status checking in comments.php

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -496,6 +496,9 @@ function callWorkflow($config, $metadata, $comment, $workflow, $extendedParamete
 function checkIfPullRequestIsOpen($metadata)
 {
     $pullRequestResponse = doRequestGitHub($metadata["token"], $metadata["pullRequestUrl"], null, "GET");
+    if ($pullRequestResponse->statusCode !== 200) {
+        return false;
+    }
     $pullRequest = json_decode($pullRequestResponse->body);
 
     $metadata["headRef"] = $pullRequest->head->ref;


### PR DESCRIPTION
### **Description**
- Added a check for the status code of the pull request response to ensure it is 200.
- Improved the function's robustness by returning `false` if the pull request is not open.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comments.php</strong><dd><code>Enhance pull request status checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/comments.php
<li>Added a status code check for pull request response.<br> <li> Improved error handling by returning false for non-200 status codes.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/475/files#diff-6cee3ad79ac51839d23c2ddd443e5c8679c8d8e744d588443f67adf7c03d7bff">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>