### PR TITLE
Enhance issue copying functionality in comments.php

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -305,7 +305,7 @@ function execute_copyIssue($config, $metadata, $comment)
     $newIssue = array("title" => $issueUpdated->title, "body" => $issueUpdated->body, "labels" => $issueUpdated->labels);
 
     $createdIssueResponse = doRequestGitHub($metadata["token"], $newIssueUrl, $newIssue, "POST");
-    if ($createdIssueResponse->statusCode !== 200) {
+    if ($createdIssueResponse->statusCode !== 201) {
         $body = "Error copying issue: {$createdIssueResponse->statusCode}";
         doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
         return;
@@ -318,6 +318,9 @@ function execute_copyIssue($config, $metadata, $comment)
 
     $body = "Issue copied to [{$targetRepository}#{$number}]({$htmlUrl})";
     doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
+
+    $body = "Issue copied from [{$comment->RepositoryOwner}/{$comment->RepositoryName}](https://github.com/{$comment->RepositoryOwner}/{$comment->RepositoryName}/issues/{$comment->PulLRequestNumber})";
+    doRequestGitHub($metadata["token"], $createdIssue->comments_url, array("body" => $body), "POST");
 }
 
 function execute_csharpier($config, $metadata, $comment)


### PR DESCRIPTION
### **Description**
- Improved the issue creation response handling by checking for a 201 status code instead of 200.
- Added a new comment to indicate the origin of the copied issue, enhancing user feedback.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comments.php</strong><dd><code>Enhance issue copying functionality in comments.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/comments.php
<li>Updated status code check from 200 to 201 for issue creation.<br> <li> Added a comment indicating the source of the copied issue.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/477/files#diff-6cee3ad79ac51839d23c2ddd443e5c8679c8d8e744d588443f67adf7c03d7bff">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>