### PR TITLE
Fix typo in comments.php for PullRequestNumber

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -320,7 +320,7 @@ function execute_copyIssue($config, $metadata, $comment)
     $body = "Issue copied to [{$targetRepository}#{$number}]({$htmlUrl})";
     doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
 
-    $body = "Issue copied from [{$comment->RepositoryOwner}/{$comment->RepositoryName}](https://github.com/{$comment->RepositoryOwner}/{$comment->RepositoryName}/issues/{$comment->PulLRequestNumber})";
+    $body = "Issue copied from [{$comment->RepositoryOwner}/{$comment->RepositoryName}](https://github.com/{$comment->RepositoryOwner}/{$comment->RepositoryName}/issues/{$comment->PullRequestNumber})";
     doRequestGitHub($metadata["token"], $createdIssue->comments_url, array("body" => $body), "POST");
 }
 


### PR DESCRIPTION
### **Description**
- Corrected the variable name from `PulLRequestNumber` to `PullRequestNumber` in the `comments.php` file.
- This change ensures that the URL for copied issues is constructed correctly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comments.php</strong><dd><code>Fix typo in PullRequestNumber variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/comments.php
<li>Fixed a typo in the variable name for PullRequestNumber.<br> <li> Updated the URL construction for copied issues.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/480/files#diff-6cee3ad79ac51839d23c2ddd443e5c8679c8d8e744d588443f67adf7c03d7bff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>