### PR TITLE
Update comment posting URL in comments.php

### DIFF
--- a/Src/comments.php
+++ b/Src/comments.php
@@ -321,7 +321,7 @@ function execute_copyIssue($config, $metadata, $comment)
     doRequestGitHub($metadata["token"], $metadata["commentUrl"], array("body" => $body), "POST");
 
     $body = "Issue copied from [{$comment->RepositoryOwner}/{$comment->RepositoryName}](https://github.com/{$comment->RepositoryOwner}/{$comment->RepositoryName}/issues/{$comment->PullRequestNumber})";
-    doRequestGitHub($metadata["token"], $createdIssue->comments_url, array("body" => $body), "POST");
+    doRequestGitHub($metadata["token"], "repos/{$targetRepository}/issues/{$number}/comments", array("body" => $body), "POST");
 }
 
 function execute_csharpier($config, $metadata, $comment)


### PR DESCRIPTION
### **Description**
- Enhanced the comment posting functionality by updating the URL format.
- This change improves the integration with GitHub's API for issue comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comments.php</strong><dd><code>Update comment posting URL in comments.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/comments.php
<li>Updated the URL used for posting comments on issues.<br> <li> Improved the clarity of the comment posting process.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/484/files#diff-6cee3ad79ac51839d23c2ddd443e5c8679c8d8e744d588443f67adf7c03d7bff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>