### PR TITLE
Update character set and collation for GitHub signature table

### DIFF
--- a/Sql/004.create_github_signature_table.sql
+++ b/Sql/004.create_github_signature_table.sql
@@ -23,6 +23,4 @@ CREATE TABLE
         `Processed` BOOLEAN NOT NULL DEFAULT FALSE,
         `ProcessedDate` TIMESTAMP NULL,
         PRIMARY KEY (`Sequence`)
-    ) ENGINE = InnoDB;
-
-ALTER TABLE `github_signature` CONVERT TO CHARACTER SET utf8;
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
### **Description**
- Enhanced the `github_signature` table by changing the default character set to `utf8mb4` and specifying the collation.
- This change improves compatibility with a wider range of characters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>004.create_github_signature_table.sql</strong><dd><code>Update character set and collation for GitHub signature table</code></dd></summary>
<hr>

Sql/004.create_github_signature_table.sql
<li>Changed the default character set to <code>utf8mb4</code>.<br> <li> Updated the table creation statement to include collation.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/489/files#diff-59b01a1f84648b6209b0bc21a2a61ca1becf1c0f9fb57146961b6b0c857510da">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>