### PR TITLE
Add OpenAPI Specification for GStraccini BOT

### DIFF
--- a/Src/swagger/v1/swagger.json
+++ b/Src/swagger/v1/swagger.json
@@ -1,0 +1,31 @@
+{
+   "openapi":"3.0.0",
+   "info":{
+      "title":"GStraccini BOT",
+      "version":"1.0.0",
+      "description":"🤖 A GitHub bot that runs on issues, pull requests, and pull request comments.",
+      "contact":{
+         "name":"API Support",
+         "url":"https://github.com/guibranco/gstraccini-bot/issues",
+         "email":"support@gstraccini.bot"
+      },
+      "license":{
+         "name":"MIT",
+         "url":"https://github.com/guibranco/gstraccini-bot/blob/main/LICENSE"
+      }
+   },
+   "servers":[
+      {
+         "url":"https://gstraccini.bot",
+         "description":"GStraccini BOT server"
+      }
+   ],
+   "tags":[
+      {
+         "name":"GStraccini BOT"
+      }
+   ],
+   "paths":{
+      
+   }
+}


### PR DESCRIPTION
### **Description**
- Introduced a new `swagger.json` file that defines the OpenAPI specification for the GStraccini BOT.
- This specification includes essential metadata and server information.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>swagger.json</strong><dd><code>Add OpenAPI Specification for GStraccini BOT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/swagger/v1/swagger.json
<li>Added OpenAPI 3.0.0 specification for the GStraccini BOT.<br> <li> Included metadata such as title, version, description, and contact <br>information.<br> <li> Defined server URL and license information.<br> <li> Created a structure for API paths and tags.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/491/files#diff-acc239102d711fe69c75d6fdcb9eedb4d6672ded46eeb5b4f61e59e5c8355d73">+31/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>