### PR TITLE
Fix variable check in GitHub response handling

### DIFF
--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -117,7 +117,7 @@ function setCheckRunInProgress($metadata, $commitId, $type)
 
     $response = doRequestGitHub($metadata["token"], $metadata["checkRunUrl"], $checkRunBody, "POST");
 
-    if ($response->statusCode >= 300 || !isset($response->body)) {
+    if ($response->statusCode >= 300 || isset($response->body) === false) {
         die("Invalid GitHub response.\n".json_encode($response));
     }
 


### PR DESCRIPTION
### **Description**
- Fixed a bug in the `setCheckRunInProgress` function by improving the condition that checks for the presence of `response->body`.
- This change enhances the reliability of the error handling when processing GitHub responses.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.php</strong><dd><code>Fix variable check in GitHub response handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/lib/github.php
<li>Changed the condition to check if <code>response->body</code> is not set.<br> <li> Improved the readability of the conditional statement.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/493/files#diff-69595ea07bc28a4778b3a81502d54299c0a3d3314cd3fc58b7c8793fd56dc5c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>