### PR TITLE
Improve URL handling for WIP label removal in pullRequests.php

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -250,7 +250,7 @@ function removeIssueWipLabel($metadata, $pullRequest)
         $labels = array_column(json_decode($issueResponse->body)->labels, "name");
 
         if (in_array("🛠 WIP", $labels)) {
-            $url = $metadata["issuesUrl"] . "/" . $issueNumber . "/labels/" . urlencode("🛠 WIP");
+            $url = $metadata["issuesUrl"] . "/" . $issueNumber . "/labels/🛠 WIP";
             doRequestGitHub($metadata["token"], $url, null, "DELETE");
         }
     }


### PR DESCRIPTION
### **Description**
- Enhanced the `removeIssueWipLabel` function to improve URL handling.
- The WIP label is now directly included in the URL without encoding.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Improve URL handling for WIP label removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/pullRequests.php
<li>Updated the URL construction for removing WIP labels.<br> <li> Changed the way the label is encoded in the URL.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/503/files#diff-a02ee044998cfd579cf9d812f74b51f079e912308e6ce6d9c1337620894ec463">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>