### PR TITLE
Fix parameter order in GitHub request method

### DIFF
--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -47,7 +47,7 @@ function doRequestGitHub($token, $url, $data, $method)
                 $response = $request->delete($url, $headers);
                 break;
             }
-            $response = $request->delete($url, $data, $headers);
+            $response = $request->delete($url, $headers, $data);
             break;
         default:
             $logger->log("Invalid method: " . $method, array("url" => $url, "method" => $method, "data" => $data));


### PR DESCRIPTION
### **Description**
- Enhanced the `doRequestGitHub` function by fixing the parameter order in the `delete` method call.
- This change improves the functionality of the GitHub request handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.php</strong><dd><code>Fix parameter order in delete method call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/lib/github.php
<li>Fixed the order of parameters in the <code>delete</code> method call.<br> <li> Improved the clarity of the code by ensuring the correct parameter <br>sequence.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/515/files#diff-69595ea07bc28a4778b3a81502d54299c0a3d3314cd3fc58b7c8793fd56dc5c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>