### PR TITLE
Improve URL encoding for WIP label in branches.php

### DIFF
--- a/Src/branches.php
+++ b/Src/branches.php
@@ -75,7 +75,7 @@ function processLabels($issue, $branch, $metadata)
     }
 
     if ($found && $branch->Event == "delete") {
-        $url = $metadata["issueUrl"] . "/labels/🛠 WIP";
+        $url = $metadata["issueUrl"] . "/labels/🛠%20WIP";
         doRequestGitHub($metadata["token"], $url, null, "DELETE");
         processRemoveAssignee($issue, $branch, $metadata);
     }


### PR DESCRIPTION
### **Description**
- Enhanced the URL encoding for the WIP label when deleting it from an issue.
- This change ensures that spaces are properly encoded, preventing potential issues with the request.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>branches.php</strong><dd><code>Improve URL encoding for WIP label deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/branches.php
<li>Updated URL encoding for WIP label in delete event.<br> <li> Ensured proper handling of spaces in the URL.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/518/files#diff-1dc16b3beaed1b74cc46fdc199e7c3b549d0da3fd03c445c9bc9e5f6efee37ef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL formatting for branch deletion events to ensure proper handling in HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->