### PR TITLE
Improve URL encoding for WIP label removal in pullRequests.php

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -250,7 +250,7 @@ function removeIssueWipLabel($metadata, $pullRequest)
         $labels = array_column(json_decode($issueResponse->body)->labels, "name");
 
         if (in_array("🛠 WIP", $labels)) {
-            $url = $metadata["issuesUrl"] . "/" . $issueNumber . "/labels/🛠 WIP";
+            $url = $metadata["issuesUrl"] . "/" . $issueNumber . "/labels/🛠%20WIP";
             doRequestGitHub($metadata["token"], $url, null, "DELETE");
         }
     }


### PR DESCRIPTION
### **Description**
- Enhanced the `removeIssueWipLabel` function to properly encode the WIP label in the URL.
- This change ensures that spaces in the label are correctly represented in the URL format.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Improve URL encoding for WIP label removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/pullRequests.php
<li>Updated URL encoding for WIP label removal.<br> <li> Ensured proper handling of spaces in URL.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/520/files#diff-a02ee044998cfd579cf9d812f74b51f079e912308e6ce6d9c1337620894ec463">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL encoding for the removal of the "WIP" label, enhancing API interaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->