### PR TITLE
Fix typo in repositories.php function

### DIFF
--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -57,7 +57,7 @@ function getDefaultOptions()
 
 function createRepositoryLabels($metadata, $options)
 {
-    if(!isset($option["labels"]) || $options["labels"] === null || $options["labels"] === "") {
+    if(!isset($options["labels"]) || $options["labels"] === null || $options["labels"] === "") {
         echo "Not creating labels\n";
         return;
     }


### PR DESCRIPTION
### **Description**
- Corrected a variable name in the `createRepositoryLabels` function to ensure proper functionality.
- This change enhances code clarity and consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.php</strong><dd><code>Fix typo in createRepositoryLabels function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repositories.php
<li>Fixed a typo in the <code>createRepositoryLabels</code> function.<br> <li> Changed <code>option</code> to <code>options</code> for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/521/files#diff-2bd0cf94e53b151fb39ae8ce66e70c2c23852b4a8c0eddba34e0780848df5fde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the label creation logic, improving the reliability of the labels option handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->