### PR TITLE
Refactor label handling in repositories.php

### DIFF
--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -110,16 +110,16 @@ function createRepositoryLabels($metadata, $options)
     foreach ($labelsToCreateObject as $label) {
         $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"], $label, "POST");
         if ($response->statusCode === 201) {
-            echo "Label created: {$label->name}\n";
+            echo "Label created: {$label["name"]}\n";
         } else {
-            echo "Error creating label: {$label->name}\n";
+            echo "Error creating label: {$label["name"]}\n";
         }
     }
 
     foreach ($labelsToUpdateObject as $oldName => $label) {
         $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"] . "/" . str_replace(" ", "%20", $oldName), $label, "PATCH");
         if ($response->statusCode === 200) {
-            echo "Label updated: {$oldName} -> {$label->new_name}\n";
+            echo "Label updated: {$oldName} -> {$label["new_name"]}\n";
         } else {
             echo "Error updating label: {$oldName}\n";
         }

--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -84,10 +84,10 @@ function createRepositoryLabels($metadata, $options)
 
         if ($total > 0) {
             $existingLabel = array_values($existingLabel);
-            $labelToUpdate = new \stdClass();
-            $labelToUpdate->color = substr($label["color"], 1);
-            $labelToUpdate->description = $label["description"];
-            $labelToUpdate->new_name = $style === "icons" ? $label["textWithIcon"] : $label["text"];
+            $labelToUpdate = array();
+            $labelToUpdate["color"] = substr($label["color"], 1);
+            $labelToUpdate["description"] = $label["description"];
+            $labelToUpdate["new_name"] = $style === "icons" ? $label["textWithIcon"] : $label["text"];
             $labelsToUpdateObject[$existingLabel[0]["name"]] = $labelToUpdate;
         }
 
@@ -96,9 +96,9 @@ function createRepositoryLabels($metadata, $options)
 
     $labelsToCreateObject = array_map(function ($label) use ($style) {
         $newLabel = new \stdClass();
-        $newLabel->color = substr($label["color"], 1);
-        $newLabel->description = $label["description"];
-        $newLabel->name = $style === "icons" ? $label["textWithIcon"] : $label["text"];
+        $newLabel["color"] = substr($label["color"], 1);
+        $newLabel["description"] = $label["description"];
+        $newLabel["name"] = $style === "icons" ? $label["textWithIcon"] : $label["text"];
         return $newLabel;
     }, $labelsToCreate);
 
@@ -108,7 +108,7 @@ function createRepositoryLabels($metadata, $options)
     echo "Creating labels {$totalLabelsToCreate} | Updating labels: {$totalLabelsToUpdate} | Style: {$style} | Categories: {$categories}\n";
 
     foreach ($labelsToCreateObject as $label) {
-        $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"], json_encode($label), "POST");
+        $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"], $label, "POST");
         if ($response->statusCode === 201) {
             echo "Label created: {$label->name}\n";
         } else {
@@ -117,7 +117,7 @@ function createRepositoryLabels($metadata, $options)
     }
 
     foreach ($labelsToUpdateObject as $oldName => $label) {
-        $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"] . "/" . str_replace(" ", "%20", $oldName), json_encode($label), "PATCH");
+        $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"] . "/" . str_replace(" ", "%20", $oldName), $label, "PATCH");
         if ($response->statusCode === 200) {
             echo "Label updated: {$oldName} -> {$label->new_name}\n";
         } else {

--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -84,7 +84,7 @@ function createRepositoryLabels($metadata, $options)
 
         if ($total > 0) {
             $existingLabel = array_values($existingLabel);
-            $labelToUpdate = array();
+            $labelToUpdate = [];
             $labelToUpdate["color"] = substr($label["color"], 1);
             $labelToUpdate["description"] = $label["description"];
             $labelToUpdate["new_name"] = $style === "icons" ? $label["textWithIcon"] : $label["text"];


### PR DESCRIPTION
### **Description**
- Refactored the `createRepositoryLabels` function to use associative arrays instead of `stdClass` for label management.
- Updated API request handling to directly use arrays, improving performance and readability.
- Enhanced overall code structure for better maintainability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.php</strong><dd><code>Refactor label handling in repository management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repositories.php
<li>Refactored label handling from <code>stdClass</code> to associative arrays.<br> <li> Updated the way labels are sent in requests to GitHub API.<br> <li> Improved code readability and maintainability.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/527/files#diff-2bd0cf94e53b151fb39ae8ce66e70c2c23852b4a8c0eddba34e0780848df5fde">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
	- Enhanced the handling of repository labels for better data structure and readability.
	- Streamlined the process of creating and updating labels, potentially improving interaction with the GitHub API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->