### PR TITLE
Refactor label creation in repositories.php

### DIFF
--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -95,7 +95,7 @@ function createRepositoryLabels($metadata, $options)
     });
 
     $labelsToCreateObject = array_map(function ($label) use ($style) {
-        $newLabel = new \stdClass();
+        $newLabel = [];
         $newLabel["color"] = substr($label["color"], 1);
         $newLabel["description"] = $label["description"];
         $newLabel["name"] = $style === "icons" ? $label["textWithIcon"] : $label["text"];


### PR DESCRIPTION
### **Description**
- Refactored the `createRepositoryLabels` function to use arrays instead of `stdClass` for label creation.
- This change improves performance and simplifies the data structure used for labels.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.php</strong><dd><code>Refactor label creation to use arrays instead of objects</code>&nbsp; </dd></summary>
<hr>

src/repositories.php
<li>Changed the creation of new labels from an object to an array.<br> <li> Updated the method of initializing <code>$newLabel</code> for better performance.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/529/files#diff-2bd0cf94e53b151fb39ae8ce66e70c2c23852b4a8c0eddba34e0780848df5fde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the label creation process to improve performance and flexibility.
  
- **Bug Fixes**
	- Resolved potential issues with label data handling by transitioning to an associative array structure. 

- **Documentation**
	- Updated documentation to reflect changes in label creation and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->