### PR TITLE
Update label handling in repositories.php

### DIFF
--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -136,7 +136,7 @@ function loadLabelsFromConfig($categories)
         $labels = json_decode($rawLabels, true);
     }
 
-    unset($labels["languages"]);
+    unset($labels["language"]);
 
     $keys = array_keys($labels);
 


### PR DESCRIPTION
### **Description**
- Updated the key being unset in `loadLabelsFromConfig` function from `languages` to `language`.
- This change ensures that the correct label is removed from the configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.php</strong><dd><code>Update label key in repositories.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repositories.php
<li>Changed the key being unset from "languages" to "language".<br> <li> Adjusted the code to ensure the correct label is removed.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/530/files#diff-2bd0cf94e53b151fb39ae8ce66e70c2c23852b4a8c0eddba34e0780848df5fde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the handling of language labels to ensure compatibility with the new configuration structure, enhancing the accuracy of label processing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->