### PR TITLE
Enhance label formatting in issues and pull requests

### DIFF
--- a/Src/issues.php
+++ b/Src/issues.php
@@ -58,7 +58,7 @@ function addLabels($issueUpdated, $collaboratorsLogins, $metadata)
 {
     $labels = [];
     if (!in_array($issueUpdated->user->login, $collaboratorsLogins)) {
-        $labels[] = "🚦awaiting triage";
+        $labels[] = "🚦 awaiting triage";
     }
 
     if ($issueUpdated->user->type === "Bot") {
@@ -74,7 +74,7 @@ function addLabels($issueUpdated, $collaboratorsLogins, $metadata)
 function removeLabels($issueUpdated, $metadata, $includeWip = false)
 {
     $labelsLookup = [
-        "🚦awaiting triage",
+        "🚦 awaiting triage",
         "⏳ awaiting response"
     ];
     if ($includeWip === true) {

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -122,7 +122,7 @@ function handleItem($pullRequest, $isRetry = false)
         }
 
         if (!in_array($pullRequest->Sender, $collaboratorsLogins)) {
-            $labelsToAdd[] = "🚦awaiting triage";
+            $labelsToAdd[] = "🚦 awaiting triage";
         }
     }
 


### PR DESCRIPTION
### **Description**
- Improved label formatting by adding a space in "🚦 awaiting triage" for consistency.
- Updated both `issues.php` and `pullRequests.php` to ensure uniformity in label usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issues.php</strong><dd><code>Update label formatting in issues.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/issues.php
<li>Added a space in the label "🚦 awaiting triage".<br> <li> Updated the label lookup for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/534/files#diff-b826551f56f9dba51ed89c86a22de45d218a71bc661b2a9371df0b9b174cea65">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Update label formatting in pullRequests.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pullRequests.php
<li>Added a space in the label "🚦 awaiting triage".<br> <li> Ensured consistent label formatting for pull requests.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/534/files#diff-84c6d7877dee9ad42a29924c3cda6620ed15394ba479a7f90dfd17eeabd65a40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved label formatting by adding a space between the emoji and text for "awaiting triage" in issue and pull request labels.
  
- **Bug Fixes**
	- Standardized label appearance to enhance readability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->