### PR TITLE
Enhance label creation handling in repositories.php

### DIFF
--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -115,6 +115,12 @@ function createRepositoryLabels($metadata, $options)
         $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"], $label, "POST");
         if ($response->statusCode === 201) {
             echo "Label created: {$label["name"]}\n";
+        } else if($response->statusCode === 422) {
+            $labelToUpdate = [];
+            $labelToUpdate["color"] = $label["color"];
+            $labelToUpdate["description"] = $label["description"];
+            $labelToUpdate["new_name"] = $label["name"];
+            $labelsToUpdateObject[$label["name"]] = $labelToUpdate;
         } else {
             echo "Error creating label: {$label["name"]}\n";
         }

--- a/Src/repositories.php
+++ b/Src/repositories.php
@@ -115,7 +115,7 @@ function createRepositoryLabels($metadata, $options)
         $response = doRequestGitHub($metadata["token"], $metadata["labelsUrl"], $label, "POST");
         if ($response->statusCode === 201) {
             echo "Label created: {$label["name"]}\n";
-        } else if($response->statusCode === 422) {
+        } elseif($response->statusCode === 422) {
             $labelToUpdate = [];
             $labelToUpdate["color"] = $label["color"];
             $labelToUpdate["description"] = $label["description"];


### PR DESCRIPTION
### **Description**
- Enhanced the `createRepositoryLabels` function to handle cases where label creation fails due to existing labels.
- Added logic to prepare an update for existing labels instead of failing silently.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.php</strong><dd><code>Enhance label creation with update handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repositories.php
<li>Added handling for existing labels with status code 422.<br> <li> Introduced logic to prepare labels for updating if creation fails.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/538/files#diff-2bd0cf94e53b151fb39ae8ce66e70c2c23852b4a8c0eddba34e0780848df5fde">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>