### PR TITLE
Enhance pull request management by removing labels on closure

### DIFF
--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -50,6 +50,7 @@ function handleItem($pullRequest, $isRetry = false)
 
     if ($pullRequestUpdated->state === "closed") {
         removeIssueWipLabel($metadata, $pullRequest);
+        removeLabels($metadata, $pullRequest);
         checkForOtherPullRequests($metadata, $pullRequest);
     }
 
@@ -137,6 +138,24 @@ function handleItem($pullRequest, $isRetry = false)
     }
 
     setCheckRunSucceeded($metadata, $checkRunId, "pull request");
+}
+
+function removeLabels($metadata, $pullRequest)
+{
+    $labelsLookup = [
+        "🚦 awaiting triage",
+        "⏳ awaiting response",
+        "🛠 WIP"
+    ];
+
+    $labels = array_column($pullRequest->labels, "name");
+    $intersect = array_intersect($labelsLookup, $labels);
+
+    foreach ($intersect as $label) {
+        $label = str_replace(" ", "%20", $label);
+        $url = $metadata["pullRequestUrl"] . "/labels/{$label}";
+        doRequestGitHub($metadata["token"], $url, null, "DELETE");
+    }
 }
 
 function checkForOtherPullRequests($metadata, $pullRequest)


### PR DESCRIPTION
### **User description**
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [ ] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.-->


___

### **Description**
- Introduced a new function `removeLabels` that removes specific labels from closed pull requests.
- This enhancement improves the management of pull request states by ensuring that unnecessary labels are cleared.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Enhance pull request handling by removing labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pullRequests.php
<li>Added a new function <code>removeLabels</code> to handle label removal from closed <br>pull requests.<br> <li> Integrated <code>removeLabels</code> function into the existing workflow when a <br>pull request is closed.<br> <li> Defined a set of labels to be removed upon closing a pull request.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/579/files#diff-84c6d7877dee9ad42a29924c3cda6620ed15394ba479a7f90dfd17eeabd65a40">+19/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>