### PR TITLE
Enhance github.php with Details URL for Check Runs

### DIFF
--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -169,6 +169,7 @@ function setCheckRunInProgress(array $metadata, string $commitId, string $type):
 {
     $checkRunBody = array(
         "name" => "GStraccini Checks: " . ucwords($type),
+        "details_url" => $metadata["dashboardUrl"],
         "head_sha" => $commitId,
         "status" => "in_progress",
         "output" => array(


### PR DESCRIPTION
### **User description**
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [ ] Yes
- [x] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.-->


___

### **Description**
- Introduced a new key `details_url` in the check run body to provide a link to the dashboard.
- This enhancement improves the visibility of the check run details for users.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.php</strong><dd><code>Enhance Check Run Body with Details URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/github.php
<li>Added a new key "details_url" to the check run body.<br> <li> The value for "details_url" is taken from the metadata array.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/586/files#diff-9a6f3af6f471feb18fa73948fb7acce5a4e803941edef873fcfb0f1bde8d52d4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>