### PR TITLE
Enhance PR Description Validation Logic

### DIFF
--- a/Src/lib/github.php
+++ b/Src/lib/github.php
@@ -265,7 +265,7 @@ function setCheckRunFailed(array $metadata, int $checkRunId, string $type, strin
  * of check that was completed. It is used to customize the check run details and message based on the
  * specific type of check being performed.
  */
-function setCheckRunSucceeded(array $metadata, int $checkRunId, string $type): void
+function setCheckRunSucceeded(array $metadata, int $checkRunId, string $type, string $details = null): void
 {
     $checkRunBody = array(
         "name" => "GStraccini Checks: " . ucwords($type),
@@ -275,7 +275,7 @@ function setCheckRunSucceeded(array $metadata, int $checkRunId, string $type): v
         "output" => array(
             "title" => "Checks completed ✅",
             "summary" => "GStraccini checked this " . strtolower($type) . " successfully!",
-            "text" => "No issues found."
+            "text" => $details ?? "No issues found."
         )
     );
 

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -163,8 +163,7 @@ function checkPullRequestDescription($metadata, $pullRequestUpdated)
         $message = $validator->generateReport($validationResult);
         setCheckRunFailed($metadata, $checkRunId, $type, $message);
         return;
-    }
-    else if ($validationResult["found"] === false || $validationResult["found"] === 0) {
+    } elseif ($validationResult["found"] === false || $validationResult["found"] === 0) {
         setCheckRunSucceeded($metadata, $checkRunId, $type, "No groups or checkboxes found in the PR body.");
     }
 

--- a/Src/pullRequests.php
+++ b/Src/pullRequests.php
@@ -164,6 +164,9 @@ function checkPullRequestDescription($metadata, $pullRequestUpdated)
         setCheckRunFailed($metadata, $checkRunId, $type, $message);
         return;
     }
+    else if ($validationResult["found"] === false || $validationResult["found"] === 0) {
+        setCheckRunSucceeded($metadata, $checkRunId, $type, "No groups or checkboxes found in the PR body.");
+    }
 
     setCheckRunSucceeded($metadata, $checkRunId, $type);
 }


### PR DESCRIPTION
### **User description**
<!-- 
Thanks for creating this pull request 🤗

Please limit the pull request to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- 
You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->
- [X] Yes
- [ ] No

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.-->


___

### **Description**
- Added a condition to handle cases where no groups or checkboxes are found in the PR body.
- Improved feedback for users by indicating when the PR body lacks necessary elements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pullRequests.php</strong><dd><code>Enhance PR Description Validation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pullRequests.php
<li>Added a new condition to check if no groups or checkboxes are found in <br>the PR body.<br> <li> Calls <code>setCheckRunSucceeded</code> with a specific message when no groups or <br>checkboxes are present.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/gstraccini-bot/pull/605/files#diff-84c6d7877dee9ad42a29924c3cda6620ed15394ba479a7f90dfd17eeabd65a40">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

